### PR TITLE
[fix] resolve 404 error on refresh and setup API proxy in netlify.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+netlify.toml

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>동국대학교 스마트캠퍼스</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/apis/admin/accounts.ts
+++ b/src/apis/admin/accounts.ts
@@ -10,7 +10,7 @@ import type { DeleteMembersResponse } from '@/types/admin/DeleteMembersResponseT
 
 /** 조회 */
 export const getAdminAccounts = async (): Promise<GetAdminAccountsResponse> => {
-  const res = await axiosInstance.get<GetAdminAccountsResponse>('/api/members');
+  const res = await axiosInstance.get<GetAdminAccountsResponse>('members');
   return res.data;
 };
 
@@ -18,7 +18,7 @@ export const getAdminAccounts = async (): Promise<GetAdminAccountsResponse> => {
 export const getAdminAccountById = async (
   id: number
 ): Promise<GetAdminAccountByIdResponse> => {
-  const res = await axiosInstance.get(`/api/members/${id}`);
+  const res = await axiosInstance.get(`members/${id}`);
   return res.data.data;
 };
 
@@ -26,7 +26,7 @@ export const getAdminAccountById = async (
 export const createAdminAccount = async (
   payload: CreateMemberRequest
 ): Promise<CreateMemberResponse> => {
-  const res = await axiosInstance.post<CreateMemberResponse>('/api/members', payload);
+  const res = await axiosInstance.post<CreateMemberResponse>('members', payload);
   return res.data;
 };
 
@@ -42,7 +42,7 @@ export const updateAdminAccount = async (
 }
 
   const res = await axiosInstance.patch<UpdateMemberResponse>(
-    `/api/members/${id}`,
+    `members/${id}`,
     body
   );
   return res.data;
@@ -53,6 +53,6 @@ export const deleteAdminAccounts = async (
   ids: number[]
 ): Promise<DeleteMembersResponse> => {
   const body: DeleteMembersRequest = { ids };
-  const res = await axiosInstance.delete<DeleteMembersResponse>('/api/members', { data: body });
+  const res = await axiosInstance.delete<DeleteMembersResponse>('members', { data: body });
   return res.data;
 };

--- a/src/apis/alarm/alarm.ts
+++ b/src/apis/alarm/alarm.ts
@@ -8,7 +8,7 @@ import type {
 // 조회
 export const getAlarmSettings = async (): Promise<AlarmSettings> => {
   const res = await axiosInstance.get<ApiEnvelope<AlarmSettings>>(
-    '/api/outliers/settings'
+    'outliers/settings'
   );
   return res.data.data;
 };
@@ -18,7 +18,7 @@ export const updateAlarmSettings = async (
   payload: UpdateAlarmSettingsRequest
 ): Promise<AlarmSettings> => {
   const res = await axiosInstance.put<ApiEnvelope<AlarmSettings>>(
-    '/api/outliers/settings',
+    'outliers/settings',
     payload
   );
   return res.data.data;

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -4,10 +4,10 @@ import type { LogInResponseData } from '@/types/auth/LogInResponseType';
 import type { LogOutResponseData } from '@/types/auth/LogOutResponseType';
 
 export const logIn = async (data: LogInRequestData): Promise<string> => {
-  const response = await axiosInstance.post<LogInResponseData>('/api/login', data);
+  const response = await axiosInstance.post<LogInResponseData>('login', data);
   return response.data.data.accessToken;
 };
 
 export const logOut = async (): Promise<void> => {
-  await axiosInstance.post<LogOutResponseData>('/api/logout');
+  await axiosInstance.post<LogOutResponseData>('logout');
 };

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_SERVER_API_URL,
+  baseURL: '/api',
   withCredentials: true,
 });
 

--- a/src/apis/documents/documents.ts
+++ b/src/apis/documents/documents.ts
@@ -9,7 +9,7 @@ import { getFilenameFromContentDisposition } from '@/utils/documents/getFilename
 export const getOutlierReport = async (
   params: GetOutlierReportRequest
 ): Promise<GetOutlierReportResponse> => {
-  const response = await axiosInstance.get<Blob>('/api/outliers/report', {
+  const response = await axiosInstance.get<Blob>('outliers/report', {
     params,
     responseType: 'blob',
   });
@@ -31,7 +31,7 @@ export const fetchOutlierReportPreview = async (params: {
   endDate: string;
 }): Promise<{ objectUrl: string; filename: string }> => {
   const response = await axiosInstance.get<Blob>(
-    "/api/outliers/report",
+    "outliers/report",
     {
       params,
       responseType: "blob",

--- a/src/apis/facilities/rooms.ts
+++ b/src/apis/facilities/rooms.ts
@@ -11,7 +11,7 @@ import type { RoomDetail } from '@/types/facilities/RoomDetail';
  */
 export const getRooms = async (params: GetRoomsRequest = {}): Promise<RoomApiResponse<GetRoomsResponse>> => {
   const response = await axiosInstance.get<RoomApiResponse<GetRoomsResponse>>(
-    '/api/rooms',
+    'rooms',
     { params }
   );
 
@@ -22,7 +22,7 @@ export const getRooms = async (params: GetRoomsRequest = {}): Promise<RoomApiRes
  * 방 상세 조회
  */
 export const getRoomDetail = async (roomId: number): Promise<RoomApiResponse<RoomDetail>> => {
-  const response = await axiosInstance.get<RoomApiResponse<RoomDetail>>(`/api/rooms/${roomId}`);
+  const response = await axiosInstance.get<RoomApiResponse<RoomDetail>>(`rooms/${roomId}`);
   return response.data;
 };
 
@@ -30,7 +30,7 @@ export const getRoomDetail = async (roomId: number): Promise<RoomApiResponse<Roo
  * 방 생성
  */
 export const createRoom = async (data: CreateRoomRequest): Promise<RoomApiResponse<Record<string, number>>> => {
-  const response = await axiosInstance.post<RoomApiResponse<Record<string, number>>>('/api/rooms', data);
+  const response = await axiosInstance.post<RoomApiResponse<Record<string, number>>>('rooms', data);
   return response.data;
 };
 
@@ -41,6 +41,6 @@ export const updateRoom = async (
   roomId: number,
   data: UpdateRoomRequest
 ): Promise<RoomApiResponse<RoomDetail>> => {
-  const response = await axiosInstance.put<RoomApiResponse<RoomDetail>>(`/api/rooms/${roomId}`, data);
+  const response = await axiosInstance.put<RoomApiResponse<RoomDetail>>(`rooms/${roomId}`, data);
   return response.data;
 };

--- a/src/apis/main/outliers.ts
+++ b/src/apis/main/outliers.ts
@@ -14,7 +14,7 @@ export const getOutliers = async (
   searchRequest?: GetOutliersRequest
 ): Promise<GetOutliersResponse> => {
   const params = { page, size, ...searchRequest };
-  const response = await axiosInstance.get<GetOutliersResponse>("/api/outliers", { params });
+  const response = await axiosInstance.get<GetOutliersResponse>("outliers", { params });
   return response.data;
 };
 
@@ -24,7 +24,7 @@ export const getOutliers = async (
 export const getOutlierDetail = async (
   outlierLogId: number
 ): Promise<GetOutlierDetailResponse> => {
-  const response = await axiosInstance.get<GetOutlierDetailResponse>(`/api/outliers/${outlierLogId}`);
+  const response = await axiosInstance.get<GetOutlierDetailResponse>(`outliers/${outlierLogId}`);
   return response.data;
 };
 
@@ -36,7 +36,7 @@ export const updateOutlierStatus = async (
   data: UpdateOutlierStatusRequest
 ): Promise<UpdateOutlierStatusResponse> => {
   const response = await axiosInstance.patch<UpdateOutlierStatusResponse>(
-    `/api/outliers/${outlierLogId}/status`,
+    `outliers/${outlierLogId}/status`,
     data
   );
   return response.data;

--- a/src/apis/measurements/roomTypes.ts
+++ b/src/apis/measurements/roomTypes.ts
@@ -8,7 +8,7 @@ import type { DeleteRoomTypeResponse } from '@/types/measurements/DeleteRoomType
  */
 export const getRoomTypes = async (page=0, size=20): Promise<GetRoomTypesResponse> => {
   const params: Record<string, any> = { page, size };
-  const response = await axiosInstance.get<GetRoomTypesResponse>('/api/rooms/types', {
+  const response = await axiosInstance.get<GetRoomTypesResponse>('rooms/types', {
     params });
   return response.data;
 };
@@ -19,7 +19,7 @@ export const getRoomTypes = async (page=0, size=20): Promise<GetRoomTypesRespons
 export const createRoomType = async (
   data: CreateRoomTypeRequest
 ): Promise<RoomTypeResponseData> => {
-  const response = await axiosInstance.post<RoomTypeResponseData>('/api/rooms/types', data);
+  const response = await axiosInstance.post<RoomTypeResponseData>('rooms/types', data);
   return response.data;
 };
 
@@ -30,7 +30,7 @@ export const updateRoomType = async (
   roomTypeId: number,
   data: CreateRoomTypeRequest
 ): Promise<RoomTypeResponseData> => {
-  const response = await axiosInstance.put<RoomTypeResponseData>(`/api/rooms/types/${roomTypeId}`, data);
+  const response = await axiosInstance.put<RoomTypeResponseData>(`rooms/types/${roomTypeId}`, data);
   return response.data;
 };
 
@@ -40,6 +40,6 @@ export const updateRoomType = async (
 export const deleteRoomType = async (
   roomTypeId: number
 ): Promise<DeleteRoomTypeResponse> => {
-  const response = await axiosInstance.delete<DeleteRoomTypeResponse>(`/api/rooms/types/${roomTypeId}`);
+  const response = await axiosInstance.delete<DeleteRoomTypeResponse>(`rooms/types/${roomTypeId}`);
   return response.data;
 };

--- a/src/apis/sensors/sensors.ts
+++ b/src/apis/sensors/sensors.ts
@@ -12,7 +12,7 @@ import type { GetSensorDataTypesResponse } from '@/types/sensors/GetSensorDataTy
 export const registerSensor = async (
   payload: RegisterSensorRequest
 ): Promise<RegisterSensorResponse> => {
-  const res = await axiosInstance.post<RegisterSensorResponse>('/api/sensors', payload, {
+  const res = await axiosInstance.post<RegisterSensorResponse>('sensors', payload, {
     headers: { 'Content-Type': 'application/json;charset=UTF-8' },
   });
   return res.data;
@@ -21,7 +21,7 @@ export const registerSensor = async (
 /** 센서 삭제 (POST /api/sensors/delete) */
 export async function deleteSensor(body: DeleteSensorBody): Promise<DeleteSensorResponse> {
   const res = await axiosInstance.post<DeleteSensorResponse>(
-    '/api/sensors/delete',
+    'sensors/delete',
     body,
     { headers: { 'Content-Type': 'application/json;charset=UTF-8' } }
   );
@@ -30,7 +30,7 @@ export async function deleteSensor(body: DeleteSensorBody): Promise<DeleteSensor
 
 /** 센서 데이터 타입 목록 (GET /api/sensors/data-types) */
 export const getSensorDataTypes = async (): Promise<GetSensorDataTypesResponse> => {
-  const res = await axiosInstance.get<GetSensorDataTypesResponse>('/api/sensors/data-types', {
+  const res = await axiosInstance.get<GetSensorDataTypesResponse>('sensors/data-types', {
     headers: { Accept: 'application/json;charset=UTF-8' },
   });
   return res.data;


### PR DESCRIPTION
## 📌 기능 설명
etlify 배포 환경에서 발생하는 SPA 라우팅 문제(새로고침 시 404 에러)와 API 통신을 위한 프록시 설정을 추가했습니다. 또한, 프로젝트의 웹페이지 타이틀을 수정했습니다.

## 📌 구현 내용
1. Netlify 설정 추가 (netlify.toml)
- API Proxy 설정: /api/*로 들어오는 요청을 백엔드 서버로 우회하도록 설정하여 CORS 문제를 방지했습니다.
- SPA Redirect 설정: 모든 경로(/*) 접근 시 index.html로 리다이렉트되도록 하여, 브라우저 새로고침 시 404 에러가 발생하는 문제를 해결했습니다.
2. Axios 설정 변경 (axiosInstance)
- axiosInstance의 baseURL을 /api로 설정했습니다. 이를 통해 모든 API 요청이 Netlify의 프록시 규칙을 타도록 변경했습니다.
3. 앱 타이틀 변경 (index.html)
- 기존 Vite 기본 타이틀을 **"동국대학교 스마트캠퍼스"**로 변경했습니다.

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->